### PR TITLE
Navigate the callstack better when creating custom assertions

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -53,7 +53,7 @@ var (
 )
 
 func TestCallerStr(t *testing.T) {
-	s := callerStr(0)
+	s := callerStr(t)
 	if len(s) <= 0 {
 		t.Errorf("return value of callerStr is empty")
 	}
@@ -63,7 +63,7 @@ func TestCallerStrf(t *testing.T) {
 	fmtStr := "%d%d"
 	val1 := 1
 	val2 := 2
-	res := callerStrf(0, fmtStr, val1, val2)
+	res := callerStrf(t, fmtStr, val1, val2)
 	if len(res) < 3 {
 		t.Errorf("return value of callerStrf is not long enough")
 	}

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -35,3 +35,15 @@ func TestErrors(t *testing.T) {
 	assert.NoErr(t, err2)
 	assert.ExistsErr(t, err1, "valid error")
 }
+
+func TestWithCustomAssertion(t *testing.T) {
+	assertCustom(t, "foobar", "foobar")
+}
+
+func assertCustom(t *testing.T, s1, s2 string) {
+	// When creating custom assertions, use assert.WithFrameWrapper to wrap t. Pass the wrapped t
+	// to other assertions. This helps the assert library rewind the callstack to the appropriate
+	// point when displaying the source of a failed assertion.
+	wt := assert.WithFrameWrapper(t)
+	assert.Equal(wt, s1, s2, "sample string")
+}


### PR DESCRIPTION
Closes #11 

This adds a new bit of functionality that makes it possible to create test helpers (custom assertions, really) without worrying that the call stack won't be unwound far enough when the source of the assertion failure is displayed.

See addition to `examples/simple_test.go` for sample usage.
